### PR TITLE
Ensure masking applied to scrubbed params/values is consistent for form/...

### DIFF
--- a/src/CodeConverters.Core/Diagnostics/DictionaryExtensions.cs
+++ b/src/CodeConverters.Core/Diagnostics/DictionaryExtensions.cs
@@ -43,7 +43,7 @@ namespace CodeConverters.Core.Diagnostics
         /// Finds dictionary keys in the <see cref="scrubParams"/> list and replaces their values
         /// with asterisks. Key comparison is case insensitive.
         /// </summary>
-         /// <param name="originalDictionary"></param>
+        /// <param name="originalDictionary"></param>
         /// <param name="scrubParams"></param>
         /// <returns></returns>
         public static IDictionary<string, string> Scrub(this IDictionary<string, string> originalDictionary, string[] scrubParams)
@@ -63,8 +63,7 @@ namespace CodeConverters.Core.Diagnostics
                 return dict;
             foreach (var key in itemsToUpdate)
             {
-                var len = dict[key] == null ? 8 : dict[key].Length;
-                dict[key] = new string('*', len);
+                dict[key] = "**********";
             }
             return dict;
         }

--- a/src/CodeConverters.MvcTests/Diagnostics/MvcErrorLogEventFixtures.cs
+++ b/src/CodeConverters.MvcTests/Diagnostics/MvcErrorLogEventFixtures.cs
@@ -26,13 +26,13 @@ namespace CodeConverters.MvcTests.Diagnostics
         public void LogsScrubbedHeaders()
         {
             var headers = _sut.ToString().Split('|').GetLogValue("Headers").Split(',').ToDictionary(k => k.Split(':')[0], v => v.Split(':')[1]);
-            Assert.Equal(headers, new Dictionary<string, string> { { "header1", "value1" }, { "header2", "value2" }, { "secret", "*********" } });
+            Assert.Equal(headers, new Dictionary<string, string> { { "header1", "value1" }, { "header2", "value2" }, { "secret", "**********" } });
         }
         [Fact]
         public void LogsScrubbedFormData()
         {
             var formData = _sut.ToString().Split('|').GetLogValue("FormData").Split(',').ToDictionary(k => k.Split(':')[0], v => v.Split(':')[1]);
-            Assert.Equal(formData, new Dictionary<string, string> { { "Form1", "valueA" }, { "form2", "valueB" }, { "password", "******" } });
+            Assert.Equal(formData, new Dictionary<string, string> { { "Form1", "valueA" }, { "form2", "valueB" }, { "password", "**********" } });
         }
     }
 }

--- a/src/CodeConverters.MvcTests/Diagnostics/MvcLogEventFixtures.cs
+++ b/src/CodeConverters.MvcTests/Diagnostics/MvcLogEventFixtures.cs
@@ -46,13 +46,13 @@ namespace CodeConverters.MvcTests.Diagnostics
         public void LogsScrubbedHeaders()
         {
             var headers = _sut.ToString().Split('|').GetLogValue("Headers").Split(',').ToDictionary(k => k.Split(':')[0], v => v.Split(':')[1]);
-            Assert.Equal(headers, new Dictionary<string, string> { { "header1", "value1" }, { "header2", "value2" }, { "secret", "*********" } });
+            Assert.Equal(headers, new Dictionary<string, string> { { "header1", "value1" }, { "header2", "value2" }, { "secret", "**********" } });
         }
         [Fact]
         public void LogsScrubbedFormData()
         {
             var formData = _sut.ToString().Split('|').GetLogValue("FormData").Split(',').ToDictionary(k => k.Split(':')[0], v => v.Split(':')[1]);
-            Assert.Equal(formData, new Dictionary<string, string> { { "Form1", "valueA" }, { "form2", "valueB" }, { "password", "******" } });
+            Assert.Equal(formData, new Dictionary<string, string> { { "Form1", "valueA" }, { "form2", "valueB" }, { "password", "**********" } });
         }
         [Fact]
         public void IsGetIsTrueOnHttpGet()

--- a/src/CodeConverters.MvcTests/Diagnostics/ScrubParams.cs
+++ b/src/CodeConverters.MvcTests/Diagnostics/ScrubParams.cs
@@ -25,7 +25,7 @@ namespace CodeConverters.MvcTests.Diagnostics
             var original = new Dictionary<string, string> {{"password", "abc123"}};
 
             var scrubbed = original.Scrub(LoggingConfig.DefaultScrubParams);
-            Assert.Equal("******", scrubbed["password"]);
+            Assert.Equal("**********", scrubbed["password"]);
             Assert.Equal("abc123", original["password"]);
 
         }


### PR DESCRIPTION
...json. If the form values use the length of the value for masking it's easy to determine which value was selected.
