### PR TITLE
upgrading to SDK 2.7

### DIFF
--- a/src/CodeConverters.Core/CodeConverters.Core.csproj
+++ b/src/CodeConverters.Core/CodeConverters.Core.csproj
@@ -39,8 +39,14 @@
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Diagnostics, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.WindowsAzure.Diagnostics, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files\Microsoft SDKs\Azure\.NET SDK\v2.7\bin\plugins\Diagnostics\Microsoft.WindowsAzure.Diagnostics.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\Program Files\Microsoft SDKs\Azure\.NET SDK\v2.7\ref\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
+    </Reference>
     <Reference Include="NewRelic.Api.Agent">
       <HintPath>..\packages\NewRelic.Agent.Api.2.24.218.0\lib\NewRelic.Api.Agent.dll</HintPath>
     </Reference>

--- a/src/CodeConverters.Core/Diagnostics/RoleLoggingConfiguration.cs
+++ b/src/CodeConverters.Core/Diagnostics/RoleLoggingConfiguration.cs
@@ -48,7 +48,7 @@ namespace CodeConverters.Core.Diagnostics
                 };
 
             Log4NetConfiguration.InitialiseLog4Net(logAppenders);
-            ConfigureAzureDiagnostics(directories);
+          //  ConfigureAzureDiagnostics(directories);
 
             ConfigureLastResortExceptionHandling();
 


### PR DESCRIPTION
remove DiagnosticMonitor initialisation as this has been deprecated.  Interim commit to test out changes