### PR TITLE
include hint path for build server

### DIFF
--- a/src/CodeConverters.Core/CodeConverters.Core.csproj
+++ b/src/CodeConverters.Core/CodeConverters.Core.csproj
@@ -39,7 +39,9 @@
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>C:\Program Files\Microsoft SDKs\Azure\.NET SDK\v2.7\bin\plugins\Diagnostics\Microsoft.WindowsAzure.Diagnostics.dll</HintPath>
+    </Reference>
     <Reference Include="NewRelic.Api.Agent">
       <HintPath>..\packages\NewRelic.Agent.Api.2.24.218.0\lib\NewRelic.Api.Agent.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Don't want to put the 2.7 SDK files in the GAC if not necessary